### PR TITLE
Rates: Cover ftm, avax, bsc, and gnosis

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@mimic-fi/v2-smart-vault": "0.1.0",
+    "@uniswap/v2-core": "^1.0.1",
     "@uniswap/v3-core": "^1.0.1",
     "@uniswap/v3-periphery": "^1.4.3"
   },

--- a/src/ERC20.ts
+++ b/src/ERC20.ts
@@ -38,7 +38,7 @@ export function loadOrCreateERC20(address: Address): ERC20Entity {
   return erc20
 }
 
-function getERC20Decimals(address: Address): i32 {
+export function getERC20Decimals(address: Address): i32 {
   let erc20Contract = ERC20Contract.bind(address)
   let decimalsCall = erc20Contract.try_decimals()
 
@@ -50,7 +50,7 @@ function getERC20Decimals(address: Address): i32 {
   return 0
 }
 
-function getERC20Name(address: Address): string {
+export function getERC20Name(address: Address): string {
   let erc20Contract = ERC20Contract.bind(address)
   let nameCall = erc20Contract.try_name()
 
@@ -62,7 +62,7 @@ function getERC20Name(address: Address): string {
   return 'Unknown'
 }
 
-function getERC20Symbol(address: Address): string {
+export function getERC20Symbol(address: Address): string {
   let erc20Contract = ERC20Contract.bind(address)
   let symbolCall = erc20Contract.try_symbol()
 

--- a/src/SmartVault.ts
+++ b/src/SmartVault.ts
@@ -41,7 +41,7 @@ import {
 } from '../types/templates/SmartVault/SmartVault'
 
 import { getWeth } from './Tokens'
-import { rateInUsd } from './UniswapV3'
+import { rateInUsd } from './rates'
 import { loadOrCreateERC20, loadOrCreateNativeToken } from './ERC20'
 import { processAuthorizedEvent, processUnauthorizedEvent } from './Permissions'
 import { getCurrentChainId } from './Networks'

--- a/src/rates/UniswapV2.ts
+++ b/src/rates/UniswapV2.ts
@@ -1,0 +1,53 @@
+import { Address, BigInt, log } from '@graphprotocol/graph-ts'
+
+import { UniswapPairV2 as UniswapPair } from '../../types/templates/SmartVault/UniswapPairV2'
+import { UniswapFactoryV2 as UniswapFactory } from '../../types/templates/SmartVault/UniswapFactoryV2'
+
+import { getUsdc, getWeth } from '../Tokens'
+
+const ZERO_ADDRESS = Address.fromString('0x0000000000000000000000000000000000000000')
+
+export function rateInUsd(token: Address, amount: BigInt, factoryAddress: Address): BigInt {
+  const USDC = getUsdc()
+  const WETH = getWeth()
+  const factory = UniswapFactory.bind(factoryAddress)
+
+  if (token.equals(USDC)) return amount
+  if (token.equals(WETH)) return convert(factory, WETH, USDC, amount)
+  return convert(factory, WETH, USDC, convert(factory, token, WETH, amount))
+}
+
+function convert(factory: UniswapFactory, tokenIn: Address, tokenOut: Address, amountIn: BigInt): BigInt {
+  if (amountIn.isZero()) return BigInt.zero()
+  let poolAddress = getPool(factory, tokenIn, tokenOut)
+  if (poolAddress.equals(ZERO_ADDRESS)) return BigInt.zero()
+
+  let reserves = getReserves(poolAddress)
+  let isTokenInLtTokenOut = tokenIn.toHexString().toLowerCase() < tokenOut.toHexString().toLowerCase()
+  let tokenInReserve = isTokenInLtTokenOut ? reserves[0] : reserves[1]
+  let tokenOutReserve = isTokenInLtTokenOut ? reserves[1] : reserves[0]
+  return amountIn.times(tokenOutReserve).div(tokenInReserve)
+}
+
+function getReserves(address: Address): Array<BigInt> {
+  let pool = UniswapPair.bind(address)
+  let reservesCall = pool.try_getReserves()
+
+  if (!reservesCall.reverted) {
+    return [reservesCall.value.value0, reservesCall.value.value1]
+  }
+
+  log.warning('getReserves() call reverted for {}', [address.toHexString()])
+  return [BigInt.zero(), BigInt.zero()]
+}
+
+function getPool(factory: UniswapFactory, tokenA: Address, tokenB: Address): Address {
+  let pairCall = factory.try_getPair(tokenA, tokenB)
+
+  if (!pairCall.reverted) {
+    return pairCall.value
+  }
+
+  log.warning('getPair() call reverted for tokens {} {}', [tokenA.toHexString(), tokenB.toHexString()])
+  return ZERO_ADDRESS
+}

--- a/src/rates/UniswapV3.ts
+++ b/src/rates/UniswapV3.ts
@@ -1,11 +1,10 @@
 import { Address, BigInt, log } from '@graphprotocol/graph-ts'
 
-import { UniswapPool } from '../types/templates/SmartVault/UniswapPool'
-import { UniswapRouter } from '../types/templates/SmartVault/UniswapRouter'
-import { UniswapFactory } from '../types/templates/SmartVault/UniswapFactory'
+import { UniswapPoolV3 as UniswapPool } from '../../types/templates/SmartVault/UniswapPoolV3'
+import { UniswapRouterV3 as UniswapRouter } from '../../types/templates/SmartVault/UniswapRouterV3'
+import { UniswapFactoryV3 as UniswapFactory } from '../../types/templates/SmartVault/UniswapFactoryV3'
 
-import { getUsdc, getWeth } from './Tokens'
-import { isEthNetwork, isMaticNetwork } from './Networks'
+import { getUsdc, getWeth } from '../Tokens'
 
 const POW_2_192 = BigInt.fromI32(2).pow(192)
 const ZERO_ADDRESS = Address.fromString('0x0000000000000000000000000000000000000000')
@@ -13,8 +12,6 @@ const ZERO_ADDRESS = Address.fromString('0x0000000000000000000000000000000000000
 export const UNISWAP_V3_ROUTER = Address.fromString('0xE592427A0AEce92De3Edee1F18E0157C05861564')
 
 export function rateInUsd(token: Address, amount: BigInt): BigInt {
-  if (!isEthNetwork() && !isMaticNetwork()) return BigInt.zero()
-
   const USDC = getUsdc()
   const WETH = getWeth()
 

--- a/src/rates/index.ts
+++ b/src/rates/index.ts
@@ -1,0 +1,20 @@
+import { Address, BigInt, log } from '@graphprotocol/graph-ts'
+
+import { rateInUsd as rateInUsdInUniV2 } from './UniswapV2'
+import { rateInUsd as rateInUsdInUniV3 } from './UniswapV3'
+import { getERC20Symbol } from '../ERC20'
+import { isArbitrum, isAvalanche, isBinance, isFantom, isGnosis, isMainnet, isOptimism, isPolygon } from '../Networks'
+
+const SUSHISWAP_FACTORY = Address.fromString('0xc35dadb65012ec5796536bd9864ed8773abc74c4')
+const HONEYSWAP_FACTORY = Address.fromString('0xA818b4F111Ccac7AA31D0BCc0806d64F2E0737D7')
+
+export function rateInUsd(token: Address, amount: BigInt): BigInt {
+  if (isMainnet() || isPolygon() || isOptimism() || isArbitrum()) return rateInUsdInUniV3(token, amount)
+  if (isFantom() || isAvalanche() || isBinance()) return rateInUsdInUniV2(token, amount, SUSHISWAP_FACTORY)
+  if (isGnosis()) return rateInUsdInUniV2(token, amount, HONEYSWAP_FACTORY)
+
+  let symbol = getERC20Symbol(token)
+  log.warning('Could not compute rate in USD for token {} ({})', [symbol, token.toHexString()])
+
+  return BigInt.zero()
+}

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -69,11 +69,15 @@ templates:
           file: ./node_modules/@mimic-fi/v2-smart-vault/artifacts/contracts/ISmartVault.sol/ISmartVault.json
         - name: ERC20
           file: ./node_modules/@uniswap/v3-periphery/artifacts/contracts/interfaces/IERC20Metadata.sol/IERC20Metadata.json
-        - name: UniswapPool
+        - name: UniswapPairV2
+          file: ./node_modules/@uniswap/v2-core/build/IUniswapV2Pair.json
+        - name: UniswapFactoryV2
+          file: ./node_modules/@uniswap/v2-core/build/IUniswapV2Factory.json
+        - name: UniswapPoolV3
           file: ./node_modules/@uniswap/v3-core/artifacts/contracts/interfaces/pool/IUniswapV3PoolState.sol/IUniswapV3PoolState.json
-        - name: UniswapFactory
+        - name: UniswapFactoryV3
           file: ./node_modules/@uniswap/v3-core/artifacts/contracts/interfaces/IUniswapV3Factory.sol/IUniswapV3Factory.json
-        - name: UniswapRouter
+        - name: UniswapRouterV3
           file: ./node_modules/@uniswap/v3-periphery/artifacts/contracts/interfaces/IPeripheryImmutableState.sol/IPeripheryImmutableState.json
       eventHandlers:
         - event: Call(indexed address,bytes,uint256,bytes,bytes)


### PR DESCRIPTION
This PR brings back UniswapV2-like exchanges to cover some missing chains when computing rates in USD like: avalanche, fantom, binance, and gnosis.